### PR TITLE
Get config from Mailman.Context when using send_bcc_and_cc like in other functions

### DIFF
--- a/lib/mailman.ex
+++ b/lib/mailman.ex
@@ -14,20 +14,21 @@ defmodule Mailman do
   def deliver(email, context, :send_cc_and_bcc, extra_headers) do
     bcc_list = email.bcc
     cleaned_email = %Mailman.Email{email | bcc: []}
+    config = Mailman.Context.get_config(context)
     message = Mailman.Render.render(cleaned_email, context.composer, extra_headers)
 
-    to_task = [Adapter.deliver(context.config, email, message)]
+    to_task = [Adapter.deliver(config, email, message)]
 
     cc_tasks = email.cc |> Enum.map(fn(address) ->  
       cc_envelope = %Mailman.Email{email | to: [address]}
-      Adapter.deliver(context.config, cc_envelope, message)
+      Adapter.deliver(config, cc_envelope, message)
     end)
 
     bcc_tasks = bcc_list |> Enum.map(fn(address) ->  
       bcc_envelope = %Mailman.Email{email | to: [address]}
       bcc_message = %Mailman.Email{email | bcc: [address]}
       message = Mailman.Render.render(bcc_message, context.composer)
-      Adapter.deliver(context.config, bcc_envelope, message)
+      Adapter.deliver(config, bcc_envelope, message)
     end)
 
     to_task ++ cc_tasks ++ bcc_tasks


### PR DESCRIPTION
Hey! I found an issue when trying to deliver a mail with BCC in my Phoenix application, it was because I have the e-mail configuration in the config files (so config as nil).  To fix that, I just changed the way we get the config. Let me know if there's anything else to be done. All the tests are passing. 