### PR TITLE
Use eiconv 1.0.0 from hex.pm

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,23 +266,6 @@ Also, if you want to clear this list:
   Mailman.TestServer.clear_deliveries
 ```
 
-## Using with Hex
-
-There's one gotcha currently when using the package with Hex. Because of the dependency on the eiconv library and it's absence in the Hex database, you have to specify it as a dependency on your own in your mix.exs
-
-As an example:
-
-```elixir
-defp deps do
-  [
-    {:mailman, "~> 0.4.0"},
-    {:eiconv, github: "zotonic/eiconv"}
-  ]
-end
-```
-
-This way you'll be able to use the parse! function to parse delivered emails.
-
 ## TODOs
 
 - [ ] Send multiple emails using the same connection [gen_smtp PR](https://github.com/Vagabond/gen_smtp/pull/117)

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,8 @@ defmodule Mailman.Mixfile do
   use Mix.Project
 
   def project do
-    [ app: :mailman,
+    [
+      app: :mailman,
       name: "Mailman",
       source_url: "https://github.com/kamilc/mailman",
       homepage_url: "https://github.com/kamilc/mailman",
@@ -10,21 +11,22 @@ defmodule Mailman.Mixfile do
       package: package(),
       version: "0.4.0",
       elixir: "~> 1.0",
-      deps: deps() ]
+      deps: deps()
+    ]
   end
 
   # Configuration for the OTP application
   def application do
-    [ applications: [:ssl, :crypto, :eiconv, :gen_smtp, :httpotion]]
+    [applications: [:ssl, :crypto, :eiconv, :gen_smtp, :httpotion]]
   end
 
   # Returns the list of dependencies in the format:
   defp deps do
     [
-      { :eiconv, "~> 1.0.0-alpha1" },
-      { :gen_smtp, "~> 0.12.0" },
-      { :ex_doc, ">= 0.16.3", only: :dev },
-      { :httpotion, "~> 3.0.0" },
+      {:eiconv, "~> 1.0.0"},
+      {:gen_smtp, "~> 0.12.0"},
+      {:ex_doc, ">= 0.16.3", only: :dev},
+      {:httpotion, "~> 3.0.0"},
       {:credo, "~> 0.8", only: [:dev, :test], runtime: false}
     ]
   end
@@ -35,9 +37,9 @@ defmodule Mailman.Mixfile do
       maintainers: ["Kamil Ciemniewski <ciemniewski.kamil@gmail.com>"],
       licenses: ["MIT"],
       links: %{
-         "GitHub" => "https://github.com/kamilc/mailman",
-         "Docs" => "http://hexdocs.pm/mailman"
-     }
+        "GitHub" => "https://github.com/kamilc/mailman",
+        "Docs" => "http://hexdocs.pm/mailman"
+      }
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,10 @@
-%{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [], [], "hexpm"},
-  "credo": {:hex, :credo, "0.8.8", "990e7844a8d06ebacd88744a55853a83b74270b8a8461c55a4d0334b8e1736c9", [], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
+%{
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
+  "credo": {:hex, :credo, "0.8.8", "990e7844a8d06ebacd88744a55853a83b74270b8a8461c55a4d0334b8e1736c9", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], []},
-  "eiconv": {:hex, :eiconv, "1.0.0-alpha1", "547da4b8abb5c85ee8e47d7b9ebfca77016b03f2869dedc91a0f0177ab67ebc4", [:rebar3], [], "hexpm"},
+  "eiconv": {:hex, :eiconv, "1.0.0", "ee1e47ee37799a05beff7a68d61f63cccc93101833c4fb94b454c23b12a21629", [:rebar3], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.16.3", "cd2a4cfe5d26e37502d3ec776702c72efa1adfa24ed9ce723bb565f4c30bd31a", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
   "gen_smtp": {:hex, :gen_smtp, "0.12.0", "97d44903f5ca18ca85cb39aee7d9c77e98d79804bbdef56078adcf905cb2ef00", [:rebar3], []},
   "httpotion": {:hex, :httpotion, "3.0.3", "17096ea1a7c0b2df74509e9c15a82b670d66fc4d66e6ef584189f63a9759428d", [:mix], [{:ibrowse, "~> 4.4", [hex: :ibrowse, optional: false]}]},
-  "ibrowse": {:hex, :ibrowse, "4.4.0", "2d923325efe0d2cb09b9c6a047b2835a5eda69d8a47ed6ff8bc03628b764e991", [:rebar3], []}}
+  "ibrowse": {:hex, :ibrowse, "4.4.0", "2d923325efe0d2cb09b9c6a047b2835a5eda69d8a47ed6ff8bc03628b764e991", [:rebar3], []},
+}


### PR DESCRIPTION
`eiconv` is on hex now and [mailman is using it](https://github.com/mailman-elixir/mailman/commit/5b57373326c0348dde3b12a3f9c706e6b161ad3b). So this removes the caveat at the end of the readme.