### PR TITLE
Prevent password from being inspected

### DIFF
--- a/lib/mailman/smtp_config.ex
+++ b/lib/mailman/smtp_config.ex
@@ -1,6 +1,7 @@
 defmodule Mailman.SmtpConfig do
   @moduledoc "A config struct for external SMTP server adapter"
 
+  @derive {Inspect, except: [:password]}
   defstruct relay: "",
     username: "",
     password: "",


### PR DESCRIPTION
This prevents someone from accidentally logging out the config struct and exposing the password to some remote log server