### PR TITLE
Updating gen_smtp from 1.0.1 to latest 1.1.1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule Mailman.Mixfile do
   defp deps do
     [
       {:eiconv, "~> 1.0.0"},
-      {:gen_smtp, "~> 1.0.1"},
+      {:gen_smtp, "~> 1.1.1"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:httpoison, "~> 1.6"},
       {:credo, "~> 1.5.0-rc.2", only: [:dev, :test], runtime: false}


### PR DESCRIPTION
Updating gen_smtp from 1.0.1 to latest 1.1.1. to resolve dependency issues when using the latest version of cowboy which requires ranch 1.8.0. 
- gen_smtp 1.0.1 rebar.config: ranch 1.6.2
- gen_smtp 1.1.1 rebar.config: ranch >= 1.7.0